### PR TITLE
MNIP-4278: add myorigin as a parameter - defaults to original value

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,6 +30,7 @@ The following parameters are available in the `profile_email` class:
 * [`virtual_aliases`](#virtual_aliases)
 * [`canonical_aliases`](#canonical_aliases)
 * [`mydomain`](#mydomain)
+* [`myorigin`](#myorigin)
 * [`relayhost`](#relayhost)
 * [`required_pkgs`](#required_pkgs)
 
@@ -58,6 +59,12 @@ Text content for the file /etc/postfix/canonical.
 Data type: `String[1]`
 
 Email domain this host is a part of. Usually just the FQDN without hostname.
+
+##### <a name="myorigin"></a>`myorigin`
+
+Data type: `String[1]`
+
+Email domain that locally-posted mail appears to come from.
 
 ##### <a name="relayhost"></a>`relayhost`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 profile_email::canonical_aliases: ~
 profile_email::mydomain: "ncsa.illinois.edu"
+profile_email::myorigin: "%{facts.fqdn}"
 profile_email::relayhost: "smtp.ncsa.illinois.edu"
 profile_email::root_mail_target: "devnull@ncsa.illinois.edu"
 profile_email::virtual_aliases: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,9 @@
 # @param mydomain
 #   Email domain this host is a part of. Usually just the FQDN without hostname.
 #
+# @param myorigin
+#   Email domain that locally-posted mail appears to come from.
+#
 # @param relayhost
 #   SMTP server to which all remote messages should be sent.
 #
@@ -24,6 +27,7 @@
 class profile_email (
   Optional[ String ] $canonical_aliases,
   String[1]          $mydomain,
+  String[1]          $myorigin,
   String[1]          $relayhost,
   Array[ String[1] ] $required_pkgs,
   Optional[ String ] $root_mail_target,
@@ -182,7 +186,7 @@ class profile_email (
     replace  => true,
     multiple => false,
     match    => '^myorigin\ =',
-    line     => "myorigin =  ${::fqdn}",
+    line     => "myorigin = ${myorigin}",
     notify   => Service[ 'postfix' ],
   }
 


### PR DESCRIPTION
fix #3 

See https://jira.ncsa.illinois.edu/browse/MNIP-4278

This was tested on `control-test-rhel8a`.