### PR TITLE
SECURITY-1497: Default smtpd_tls_security_level to none

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ profile_email::inet_interfaces:
   - "172.0.0.2"     # IP OF LOCAL INTERFACE TO LISTEN ON
 profile_email::mynetworks:
   - "172.0.0.0/24"  # SUBNET TO ALLOW RELAYING
+profile_email::smtpd_tls_security_level: "none"
 ```
 
 ## Dependencies

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,29 +26,16 @@ include profile_email
 
 The following parameters are available in the `profile_email` class:
 
-* [`root_mail_target`](#root_mail_target)
-* [`virtual_aliases`](#virtual_aliases)
 * [`canonical_aliases`](#canonical_aliases)
 * [`inet_interfaces`](#inet_interfaces)
 * [`mydomain`](#mydomain)
 * [`myorigin`](#myorigin)
 * [`mynetworks`](#mynetworks)
 * [`relayhost`](#relayhost)
+* [`root_mail_target`](#root_mail_target)
+* [`smtpd_tls_security_level`](#smtpd_tls_security_level)
+* [`virtual_aliases`](#virtual_aliases)
 * [`required_pkgs`](#required_pkgs)
-
-##### <a name="root_mail_target"></a>`root_mail_target`
-
-Data type: `Optional[ String ]`
-
-To where should root mail be sent.
-Mutually exclusive with virtual_aliases.
-
-##### <a name="virtual_aliases"></a>`virtual_aliases`
-
-Data type: `Optional[ String ]`
-
-Text content for the file /etc/postfix/virtual.
-Mutually exclusive with root_mail_target.
 
 ##### <a name="canonical_aliases"></a>`canonical_aliases`
 
@@ -85,6 +72,27 @@ List of IPs and/or subnet CIDRs of trusted network SMTP clients.
 Data type: `String[1]`
 
 SMTP server to which all remote messages should be sent.
+
+##### <a name="root_mail_target"></a>`root_mail_target`
+
+Data type: `Optional[ String ]`
+
+To where should root mail be sent.
+Mutually exclusive with virtual_aliases.
+
+##### <a name="smtpd_tls_security_level"></a>`smtpd_tls_security_level`
+
+Data type: `String[1]`
+
+SMTP TLS security level for the Postfix SMTP server.
+See https://www.postfix.org/postconf.5.html#smtpd_tls_security_level
+
+##### <a name="virtual_aliases"></a>`virtual_aliases`
+
+Data type: `Optional[ String ]`
+
+Text content for the file /etc/postfix/virtual.
+Mutually exclusive with root_mail_target.
 
 ##### <a name="required_pkgs"></a>`required_pkgs`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,4 +6,5 @@ profile_email::myorigin: "%{facts.fqdn}"
 profile_email::mynetworks: []
 profile_email::relayhost: "smtp.ncsa.illinois.edu"
 profile_email::root_mail_target: "devnull@ncsa.illinois.edu"
+profile_email::smtpd_tls_security_level: "none"
 profile_email::virtual_aliases: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,14 +2,6 @@
 #
 # Basic email and SMTP setup
 #
-# @param root_mail_target
-#   To where should root mail be sent.
-#   Mutually exclusive with virtual_aliases.
-#
-# @param virtual_aliases
-#   Text content for the file /etc/postfix/virtual.
-#   Mutually exclusive with root_mail_target.
-#
 # @param canonical_aliases
 #   Text content for the file /etc/postfix/canonical.
 #
@@ -28,6 +20,18 @@
 # @param relayhost
 #   SMTP server to which all remote messages should be sent.
 #
+# @param root_mail_target
+#   To where should root mail be sent.
+#   Mutually exclusive with virtual_aliases.
+#
+# @param smtpd_tls_security_level
+#   SMTP TLS security level for the Postfix SMTP server.
+#   See https://www.postfix.org/postconf.5.html#smtpd_tls_security_level
+#
+# @param virtual_aliases
+#   Text content for the file /etc/postfix/virtual.
+#   Mutually exclusive with root_mail_target.
+#
 # @example
 #   include profile_email
 class profile_email (
@@ -39,6 +43,7 @@ class profile_email (
   String[1]          $relayhost,
   Array[ String[1] ] $required_pkgs,
   Optional[ String ] $root_mail_target,
+  String[1]          $smtpd_tls_security_level,
   Optional[ String ] $virtual_aliases,
 ) {
 
@@ -141,6 +146,14 @@ class profile_email (
     replace => true,
     match   => '^masquerade_classes\ =',
     line    => 'masquerade_classes = envelope_sender, header_sender, header_recipient',
+    notify  => Service[ 'postfix' ],
+  }
+
+  file_line { 'postfix_smtpd_tls_security_level':
+    path    => '/etc/postfix/main.cf',
+    replace => true,
+    match   => '^smtpd_tls_security_level\ =',
+    line    => "smtpd_tls_security_level = ${smtpd_tls_security_level}",
     notify  => Service[ 'postfix' ],
   }
 


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SECURITY-1497

This is a followup to #5 which optionally allows hosts within a cluster to relay SMTP traffic.
Apparently the default settings for `smtpd_tls_security_level` is to use `may`, which turns on 'Opportunistic TLS'. See https://www.postfix.org/postconf.5.html#smtpd_tls_security_level  That ends up enabling TLS with generic certificates which would not be setup on a server. So in general we want to set `smtpd_tls_security_level` to `none` disabling TLS. If TLS is needed, then it can be manually set.

This is being tested on `control-test-rhel84b`.
- `control-test-rhel86a` is temporarily setup to relay through `control-test-rhel84b`.

