### PR TITLE
SVCPLAN-3455 Change myhostname to be parameterized

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,7 @@ profile_email::canonical_aliases: ~
 profile_email::inet_interfaces: []
 profile_email::mydomain: "ncsa.illinois.edu"
 profile_email::myorigin: "%{facts.fqdn}"
+profile_email::myhostname: "%{::fqdn}"
 profile_email::mynetworks: []
 profile_email::relayhost: "smtp.ncsa.illinois.edu"
 profile_email::root_mail_target: "devnull@ncsa.illinois.edu"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,9 @@
 # @param mydomain
 #   Email domain this host is a part of. Usually just the FQDN without hostname.
 #
+# @param myhostname
+#   Email hostname that locally-posted mail appears to come from.
+#
 # @param myorigin
 #   Email domain that locally-posted mail appears to come from.
 #
@@ -39,6 +42,7 @@ class profile_email (
   Array[String[1]]   $inet_interfaces,
   String[1]          $mydomain,
   String[1]          $myorigin,
+  String[1]          $myhostname,
   Array[String[1]]   $mynetworks,
   String[1]          $relayhost,
   Array[ String[1] ] $required_pkgs,
@@ -113,7 +117,7 @@ class profile_email (
     path    => '/etc/postfix/main.cf',
     replace => true,
     match   => '^myhostname\ =',
-    line    => "myhostname = ${::fqdn}",
+    line    => "myhostname = ${myhostname}",
     notify  => Service[ 'postfix' ],
   }
 


### PR DESCRIPTION
Change myhostname to be parameterized to allow the hostname to be different than ${::fqdn} which is the puppet cert name. The default in the common.yaml is still ${::fqdn}. 